### PR TITLE
Reworks the module to enable multiple device types each with own implementation for status, state and different callbacks.

### DIFF
--- a/example-inverter.py
+++ b/example-inverter.py
@@ -1,23 +1,25 @@
 # example.py
 
 import logging
-from qilowatt import QilowattMQTTClient, EnergyData, MetricsData
+from qilowatt import QilowattMQTTClient
+from qilowatt import EnergyData, MetricsData
+from qilowatt import InverterDevice
 import time
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
 # User-provided MQTT credentials and inverter ID
-mqtt_username = 'your_username'
-mqtt_password = 'your_password'
-inverter_id = 'your_inverter_id'
+mqtt_username = ''
+mqtt_password = ''
+device = InverterDevice(device_id='')
 
 # Create the Qilowatt MQTT client
 client = QilowattMQTTClient(
     mqtt_username=mqtt_username,
     mqtt_password=mqtt_password,
-    inverter_id=inverter_id,
-    host='test-mqtt.qilowatt.it',
+    device=device,
+    host='mqtt.qilowatt.it',
     port=8883,
     tls=True
 )
@@ -25,7 +27,7 @@ def on_command_received(command):
     print(f"Received WorkMode Command: {command}")
 
 # Set the command callback
-client.set_command_callback(on_command_received)
+device.set_command_callback(on_command_received)
 
 # Connect to the MQTT broker
 client.connect()
@@ -59,8 +61,8 @@ metrics_data = MetricsData(
 )
 
 # Set the data
-client.set_energy_data(energy_data)
-client.set_metrics_data(metrics_data)
+device.set_energy_data(energy_data)
+device.set_metrics_data(metrics_data)
 
 # Now the module will automatically start sending data at the specified intervals
 
@@ -72,7 +74,7 @@ try:
         time.sleep(30)
         # Update ENERGY data if needed
         energy_data.Today += 0.1
-        client.set_energy_data(energy_data)
+        device.set_energy_data(energy_data)
 except KeyboardInterrupt:
     print("Exiting...")
 finally:

--- a/example-switch.py
+++ b/example-switch.py
@@ -1,0 +1,47 @@
+import logging
+from qilowatt import QilowattMQTTClient
+from qilowatt import SwitchDevice
+import time
+
+# Configure logging
+logging.basicConfig(level=logging.DEBUG)
+
+# User-provided MQTT credentials and device ID
+mqtt_username = ''
+mqtt_password = ''
+device = SwitchDevice(device_id='')
+
+# Create the Qilowatt MQTT client
+client = QilowattMQTTClient(
+    mqtt_username=mqtt_username,
+    mqtt_password=mqtt_password,
+    device=device,
+    host='mqtt.qilowatt.it',
+    port=8883,
+    tls=True
+)
+def on_command_received(state):
+    print(f"Switch status: {state}")
+
+# Connect to the MQTT broker
+client.connect()
+
+device.set_command_callback(on_command_received)
+
+# Wait a moment to ensure connection is established
+time.sleep(2)
+
+# Keep the script running to receive commands and send data
+try:
+    print("Running. Press Ctrl+C to exit.")
+    while True:
+        # Simulate updating data periodically
+        time.sleep(30)
+        # Turn the switch on or off
+        device.turn_on()
+        time.sleep(30)
+        device.turn_off()
+except KeyboardInterrupt:
+    print("Exiting...")
+finally:
+    client.disconnect()

--- a/src/qilowatt/__init__.py
+++ b/src/qilowatt/__init__.py
@@ -11,6 +11,8 @@ from .exceptions import (
     ConnectionError,
     AuthenticationError,
 )
+from .devices.inverter import InverterDevice
+from .devices.switch import SwitchDevice
 
 try:
     from ._version import version as __version__
@@ -19,6 +21,8 @@ except ImportError:
 
 __all__ = [
     "QilowattMQTTClient",
+    "InverterDevice",
+    "SwitchDevice",
     "EnergyData",
     "MetricsData",
     "WorkModeCommand",

--- a/src/qilowatt/base_device.py
+++ b/src/qilowatt/base_device.py
@@ -1,0 +1,201 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Dict, Any, Callable
+import threading
+import logging
+from datetime import datetime, timezone
+from .models import (
+    Status0Data,
+    StatusData, StatusPRMData, StatusFWRData, StatusLOGData,
+    StatusNETData, StatusMQTData, StatusTIMData
+)
+import platform
+import socket
+import getmac
+
+_logger = logging.getLogger(__name__)
+
+class BaseDevice(ABC):
+    """Base class for all devices that can communicate via MQTT."""
+    
+    def __init__(self, device_id: str):
+        self.device_id = device_id
+        self._data_initialized = False
+        self._sensor_timer_thread: Optional[threading.Thread] = None
+        self._state_timer_thread: Optional[threading.Thread] = None
+        self._status0_timer_thread: Optional[threading.Thread] = None
+        
+        self._sensor_timer_stop_event = threading.Event()
+        self._state_timer_stop_event = threading.Event()
+        self._status0_timer_stop_event = threading.Event()
+        
+        self._startup_utc = datetime.utcnow()
+        self._boot_count = 1
+        
+    @property
+    def sensor_topic(self) -> str:
+        """Get the sensor topic for this device."""
+        return f"Q/{self.device_id}/SENSOR"
+        
+    @property
+    def state_topic(self) -> str:
+        """Get the state topic for this device."""
+        return f"Q/{self.device_id}/STATE"
+
+    @property
+    def power_topic(self) -> str:
+        """Send POWER1 state."""
+        return f"Q/{self.device_id}/POWER1"
+
+
+    @property
+    def status0_topic(self) -> str:
+        """Get the status topic for this device."""
+        return f"Q/{self.device_id}/STATUS0"
+        
+    @property
+    def command_topic(self) -> str:
+        """Get the command topic for this device."""
+        return f"Q/{self.device_id}/cmnd/backlog"
+    
+    @abstractmethod
+    def handle_command(self, payload: bytes) -> None:
+        """Handle incoming command messages."""
+        pass
+    
+    @abstractmethod
+    def get_sensor_data(self) -> Dict[str, Any]:
+        """Get current sensor data."""
+        pass
+        
+    @abstractmethod
+    def get_state_data(self) -> Dict[str, Any]:
+        """Get current state data."""
+        pass
+    
+    def start_timers(self):
+        """Start all data publishing timers."""
+        self._start_sensor_timer()
+        self._start_state_timer()
+        self._start_status0_timer()
+    
+    def stop_timers(self):
+        """Stop all data publishing timers."""
+        for event in [self._sensor_timer_stop_event, 
+                     self._state_timer_stop_event, 
+                     self._status0_timer_stop_event]:
+            event.set()
+            
+        for thread in [self._sensor_timer_thread, 
+                      self._state_timer_thread, 
+                      self._status0_timer_thread]:
+            if thread:
+                thread.join()
+                
+        # Reset events and threads
+        self._sensor_timer_stop_event.clear()
+        self._state_timer_stop_event.clear()
+        self._status0_timer_stop_event.clear()
+        self._sensor_timer_thread = None
+        self._state_timer_thread = None
+        self._status0_timer_thread = None
+
+    def publish_sensor_data(self):
+        sensor_data = self.get_sensor_data()
+        # Callback will be set by client
+        if hasattr(self, '_publish_callback'):
+            self._publish_callback(self.sensor_topic, sensor_data)
+
+    def _start_sensor_timer(self):
+        """Start timer for sending sensor data."""
+        def sensor_timer():
+            while not self._sensor_timer_stop_event.wait(10):
+                self.publish_sensor_data()
+                    
+        self._sensor_timer_thread = threading.Thread(
+            target=sensor_timer, 
+            name=f"{self.__class__.__name__}SensorTimer"
+        )
+        self._sensor_timer_thread.daemon = True
+        self._sensor_timer_thread.start()
+
+    def publish_state_data(self):
+        state_data = self.get_state_data()
+        if hasattr(self, '_publish_callback'):
+            self._publish_callback(self.state_topic, state_data)
+
+    def _start_state_timer(self):
+        """Start timer for sending state data."""
+        def state_timer():
+            while not self._state_timer_stop_event.wait(60):
+                self.publish_state_data()
+
+        self._state_timer_thread = threading.Thread(
+            target=state_timer, 
+            name=f"{self.__class__.__name__}StateTimer"
+        )
+        self._state_timer_thread.daemon = True
+        self._state_timer_thread.start()
+
+    def _start_status0_timer(self):
+        """Start timer for sending status data."""
+        def status0_timer():
+            # Send at startup
+            status0_data = self.get_status0_data()
+            if hasattr(self, '_publish_callback'):
+                self._publish_callback(self.status0_topic, status0_data.to_dict())
+            # Then every 60 minutes
+            while not self._status0_timer_stop_event.wait(3600):
+                status0_data = self.get_status0_data()
+                if hasattr(self, '_publish_callback'):
+                    self._publish_callback(self.status0_topic, status0_data.to_dict())
+                    
+        self._status0_timer_thread = threading.Thread(
+            target=status0_timer, 
+            name=f"{self.__class__.__name__}Status0Timer"
+        )
+        self._status0_timer_thread.daemon = True
+        self._status0_timer_thread.start()
+
+    def get_status0_data(self) -> Status0Data:
+        """Get current status data."""
+        # Implementation remains the same as in the original code
+        # Creating all required status objects...
+        status = StatusData(
+            DeviceName="Qilowatt Inverter",
+            FriendlyName=["Home Assistant", "", ""],
+            Topic=self.device_id
+        )
+        
+        status_prm = StatusPRMData(
+            StartupUTC=self._startup_utc.replace(tzinfo=timezone.utc).isoformat(),
+            BootCount=self._boot_count
+        )
+                
+        return Status0Data(
+            Status=status,
+            StatusPRM=status_prm,
+            StatusFWR=StatusFWRData(Version="1.0.0", Hardware=platform.machine()),
+            StatusLOG=StatusLOGData(TelePeriod=10),
+            StatusNET=StatusNETData(
+                Hostname=socket.gethostname(),
+                IPAddress=socket.gethostbyname(socket.gethostname()),
+                Gateway="192.168.1.1",
+                Subnetmask="255.255.255.0",
+                Mac=getmac.get_mac_address()
+            ),
+            StatusMQT=StatusMQTData(
+                MqttHost="mqtt-test.qilowatt.it",
+                MqttPort=8883,
+                MqttClient="",
+                MqttUser="",
+                MqttClientMask="QWAPI_%06X"
+            ),
+            StatusTIM=StatusTIMData(
+                UTC=datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
+                Local=datetime.now().isoformat()
+            )
+        )
+
+    def set_publish_callback(self, callback: Callable[[str, Dict[str, Any]], None]):
+        """Set callback for publishing data."""
+        self._publish_callback = callback

--- a/src/qilowatt/client.py
+++ b/src/qilowatt/client.py
@@ -5,13 +5,9 @@ import json
 import threading
 import logging
 import paho.mqtt.client as mqtt
-from typing import Callable, Optional
-from .models import SensorData, WorkModeCommand, EnergyData, MetricsData, Status0Data, StatusData, StatusPRMData, StatusFWRData, StatusLOGData, StatusNETData, StatusMQTData, StatusTIMData
+from typing import Dict, Any
 from .exceptions import ConnectionError, AuthenticationError
-from datetime import datetime, timezone
-import platform
-import socket
-import getmac
+from .base_device import BaseDevice
 
 _logger = logging.getLogger(__name__)
 
@@ -22,14 +18,14 @@ class QilowattMQTTClient:
         self,
         mqtt_username: str,
         mqtt_password: str,
-        inverter_id: str,
+        device: BaseDevice,
         host: str = "mqtt.qilowatt.it",
         port: int = 8883,
         tls: bool = True,
     ):
         self.mqtt_username = mqtt_username
         self.mqtt_password = mqtt_password
-        self.inverter_id = inverter_id
+        self.device = device
 
         self.host = host
         self.port = port
@@ -39,37 +35,18 @@ class QilowattMQTTClient:
         self._connected = False
         self._lock = threading.Lock()
 
-        self._sensor_topic = f"Q/{self.inverter_id}/SENSOR"
-        self._state_topic = f"Q/{self.inverter_id}/STATE"
-        self._status0_topic = f"Q/{self.inverter_id}/STATUS0"
-        self._command_topic = f"Q/{self.inverter_id}/cmnd/backlog"
-
-        self._workmode_command: Optional[WorkModeCommand] = None  # Store the latest command
-        self._workmode_command = WorkModeCommand.from_dict({"Mode": "normal"})  # Default to normal mode
-
-        self._on_command_callback: Optional[Callable[[WorkModeCommand], None]] = None
-
-        # Data storage
-        self._energy_data: Optional[EnergyData] = None
-        self._metrics_data: Optional[MetricsData] = None
-
-        # Timers
-        self._sensor_timer_thread: Optional[threading.Thread] = None
-        self._state_timer_thread: Optional[threading.Thread] = None
-        self._status0_timer_thread: Optional[threading.Thread] = None
-
-        self._sensor_timer_stop_event = threading.Event()
-        self._state_timer_stop_event = threading.Event()
-        self._status0_timer_stop_event = threading.Event()
-
-        # Flags to indicate whether data has been initialized
-        self._data_initialized = False
-
-        # Initialize startup time and boot count
-        self._startup_utc = datetime.utcnow()
-        self._boot_count = 1  # Increment as appropriate
-
         self._setup_client()
+
+        # Set up device callback
+        def publish_callback(topic: str, data: Dict[str, Any]):
+            if self._connected:
+                payload = json.dumps(data)
+                self._client.publish(topic, payload)
+                _logger.debug(f"Published data to {topic}")
+            else:
+                _logger.warning(f"Cannot publish to {topic}: not connected")
+        
+        self.device.set_publish_callback(publish_callback)
 
     def _setup_client(self):
         if self.tls:
@@ -86,7 +63,7 @@ class QilowattMQTTClient:
         if rc == 0:
             self._connected = True
             # Subscribe to command topic
-            client.subscribe(self._command_topic)
+            client.subscribe(self.device.command_topic)
         elif rc == 5:
             raise AuthenticationError("Authentication failed")
         else:
@@ -98,233 +75,8 @@ class QilowattMQTTClient:
 
     def _on_message(self, client, userdata, msg):
         _logger.debug(f"Message received on {msg.topic}: {msg.payload}")
-        if msg.topic == self._command_topic:
-            self._handle_command_message(msg.payload)
-
-    def _handle_command_message(self, payload):
-        try:
-            message = payload.decode('utf-8')
-            if message.startswith("WORKMODE"):
-                json_part = message[len("WORKMODE "):]
-                data = json.loads(json_part)
-                command = WorkModeCommand.from_dict(data)
-                self._workmode_command = command  # Store internally
-                if self._on_command_callback:
-                    self._on_command_callback(command)
-        except Exception as e:
-            _logger.error(f"Error processing command message: {e}")
-
-    def set_command_callback(self, callback: Callable[[WorkModeCommand], None]):
-        """Set the callback function to be called when a command is received."""
-        self._on_command_callback = callback
-
-    def set_energy_data(self, energy_data: EnergyData):
-        """Set the ENERGY data."""
-        self._energy_data = energy_data
-        self._check_data_initialized()
-
-    def set_metrics_data(self, metrics_data: MetricsData):
-        """Set the METRICS data."""
-        self._metrics_data = metrics_data
-        self._check_data_initialized()
-
-    def _check_data_initialized(self):
-        if self._energy_data and self._metrics_data and not self._data_initialized:
-            self._data_initialized = True
-            self._start_timers()
-
-    def _start_timers(self):
-        # Start the timers for sending data
-        self._start_sensor_timer()
-        self._start_state_timer()
-        self._start_status0_timer()
-
-    def _start_sensor_timer(self):
-        def sensor_timer():
-            while not self._sensor_timer_stop_event.wait(10):
-                self.publish_sensor_data()
-
-        self._sensor_timer_thread = threading.Thread(target=sensor_timer, name="SensorTimer")
-        self._sensor_timer_thread.daemon = True
-        self._sensor_timer_thread.start()
-        _logger.debug("Started sensor data timer.")
-
-    def _start_state_timer(self):
-        def state_timer():
-            while not self._state_timer_stop_event.wait(60):
-                self.publish_state_data()
-
-        self._state_timer_thread = threading.Thread(target=state_timer, name="StateTimer")
-        self._state_timer_thread.daemon = True
-        self._state_timer_thread.start()
-        _logger.debug("Started state data timer.")
-
-    def _start_status0_timer(self):
-        def status0_timer():
-            # Send at startup
-            self.publish_status0_data()
-            # Then every 60 minutes
-            while not self._status0_timer_stop_event.wait(3600):
-                self.publish_status0_data()
-
-        self._status0_timer_thread = threading.Thread(target=status0_timer, name="Status0Timer")
-        self._status0_timer_thread.daemon = True
-        self._status0_timer_thread.start()
-        _logger.debug("Started STATUS0 data timer.")
-
-    def publish_sensor_data(self):
-        """Publish sensor data to the MQTT broker."""
-        if self._connected and self._data_initialized:
-            # Build the sensor data
-            sensor_data = SensorData(
-                ENERGY=self._energy_data,
-                METRICS=self._metrics_data,
-                WORKMODE=self._workmode_command  # Use the latest WORKMODE command
-            )
-            # Update the time
-            sensor_data.Time = datetime.utcnow().isoformat()
-            payload = json.dumps(sensor_data.to_dict())
-            self._client.publish(self._sensor_topic, payload)
-            _logger.debug(f"Published sensor data to {self._sensor_topic}")
-        else:
-            _logger.warning("Cannot publish sensor data: not connected or data not initialized.")
-
-    def publish_state_data(self):
-        """Publish state data to the MQTT broker."""
-        if self._connected:
-            state_data = self.generate_state_data()
-            payload = json.dumps(state_data)
-            self._client.publish(self._state_topic, payload)
-            _logger.debug(f"Published state data to {self._state_topic}")
-        else:
-            _logger.warning("Cannot publish state data: not connected.")
-
-    def generate_state_data(self):
-        """Generate the STATE data."""
-        state_data = {
-            "Time": datetime.utcnow().isoformat(),
-            # Add other state fields as necessary
-            # For example:
-            "Uptime": int((datetime.utcnow() - self._startup_utc).total_seconds()),
-        }
-        return state_data
-
-    def publish_status0_data(self):
-        """Publish STATUS0 data to the MQTT broker."""
-        if self._connected:
-            status0_data = self.generate_status0_data()
-            payload = json.dumps(status0_data.to_dict())
-            self._client.publish(self._status0_topic, payload)
-            _logger.debug(f"Published STATUS0 data to {self._status0_topic}")
-        else:
-            _logger.warning("Cannot publish STATUS0 data: not connected.")
-
-    def generate_status0_data(self) -> Status0Data:
-        """Generate the STATUS0 data."""
-        # Automatically determine some values
-        device_name = "Qilowatt Device"
-        friendly_name = ["Home Assistant", "", ""]
-        topic = self.inverter_id  # Assuming inverter_id is unique
-
-        startup_utc = self._startup_utc.replace(tzinfo=timezone.utc).isoformat()
-        boot_count = self._boot_count
-
-        version = "QW-MQTT-API-24.10.01"  # Example version
-        hardware = platform.machine()
-
-        tele_period = 10  # Example telemetry period
-
-        hostname = socket.gethostname()
-        ip_address = self._get_ip_address()
-        gateway = self._get_default_gateway()
-        subnet_mask = self._get_subnet_mask()
-        mac_address = getmac.get_mac_address()
-
-        mqtt_host = self.host
-        mqtt_port = self.port
-        mqtt_client = self._client._client_id.decode('utf-8') if self._client._client_id else ''
-        mqtt_user = self.mqtt_username
-
-        utc_now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
-        local_now = datetime.now().isoformat()
-
-        status = StatusData(
-            DeviceName=device_name,
-            FriendlyName=friendly_name,
-            Topic=topic,
-        )
-
-        status_prm = StatusPRMData(
-            StartupUTC=startup_utc,
-            BootCount=boot_count,
-        )
-
-        status_fwr = StatusFWRData(
-            Version=version,
-            Hardware=hardware,
-        )
-
-        status_log = StatusLOGData(
-            TelePeriod=tele_period,
-        )
-
-        status_net = StatusNETData(
-            Hostname=hostname,
-            IPAddress=ip_address,
-            Gateway=gateway,
-            Subnetmask=subnet_mask,
-            Mac=mac_address,
-        )
-
-        mqtt_client_mask = "QWAPI_%06X"  # Example mask
-
-        status_mqt = StatusMQTData(
-            MqttHost=mqtt_host,
-            MqttPort=mqtt_port,
-            MqttClient=mqtt_client,
-            MqttUser=mqtt_user,
-            MqttClientMask=mqtt_client_mask,
-        )
-
-        status_tim = StatusTIMData(
-            UTC=utc_now,
-            Local=local_now,
-        )
-
-        status0_data = Status0Data(
-            Status=status,
-            StatusPRM=status_prm,
-            StatusFWR=status_fwr,
-            StatusLOG=status_log,
-            StatusNET=status_net,
-            StatusMQT=status_mqt,
-            StatusTIM=status_tim,
-        )
-
-        return status0_data
-
-    # Helper methods to retrieve network information
-    def _get_ip_address(self):
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            # This IP is not used; it's just to get the appropriate interface
-            s.connect(("8.8.8.8", 80))
-            ip_address = s.getsockname()[0]
-            s.close()
-            return ip_address
-        except Exception as e:
-            _logger.error(f"Error getting IP address: {e}")
-            return "0.0.0.0"
-
-    def _get_default_gateway(self):
-        # Implement logic to retrieve default gateway
-        # Placeholder implementation
-        return "192.168.1.1"
-
-    def _get_subnet_mask(self):
-        # Implement logic to retrieve subnet mask
-        # Placeholder implementation
-        return "255.255.255.0"
+        if msg.topic == self.device.command_topic:
+            self.device.handle_command(msg.payload)
 
     def connect(self):
         """Connect to the MQTT broker and start the loop."""
@@ -340,33 +92,4 @@ class QilowattMQTTClient:
                 self._client.loop_stop()
                 self._client.disconnect()
                 self._connected = False
-        self._stop_timers()
-
-    def _stop_timers(self):
-        """Stop all running timers."""
-        if self._sensor_timer_thread:
-            self._sensor_timer_stop_event.set()
-            self._sensor_timer_thread.join()
-            _logger.debug("Stopped sensor data timer.")
-
-        if self._state_timer_thread:
-            self._state_timer_stop_event.set()
-            self._state_timer_thread.join()
-            _logger.debug("Stopped state data timer.")
-
-        if self._status0_timer_thread:
-            self._status0_timer_stop_event.set()
-            self._status0_timer_thread.join()
-            _logger.debug("Stopped STATUS0 data timer.")
-
-        # Reset events and threads
-        self._sensor_timer_stop_event.clear()
-        self._state_timer_stop_event.clear()
-        self._status0_timer_stop_event.clear()
-        self._sensor_timer_thread = None
-        self._state_timer_thread = None
-        self._status0_timer_thread = None
-
-    def get_workmode_command(self) -> Optional[WorkModeCommand]:
-        """Get the latest WORKMODE command received."""
-        return self._workmode_command
+        self.device._stop_timers()

--- a/src/qilowatt/devices/inverter.py
+++ b/src/qilowatt/devices/inverter.py
@@ -1,0 +1,74 @@
+from ..base_device import BaseDevice
+from ..models import (
+    EnergyData, MetricsData, WorkModeCommand
+)
+import json
+import logging
+from datetime import datetime
+from typing import Optional, Dict, Any, Callable
+
+_logger = logging.getLogger(__name__)
+
+class InverterDevice(BaseDevice):
+    """Implementation of an inverter device."""
+    
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self._energy_data: Optional[EnergyData] = None
+        self._metrics_data: Optional[MetricsData] = None
+        self._workmode_command = WorkModeCommand.from_dict({"Mode": "normal"})
+        self._on_command_callback: Optional[Callable[[WorkModeCommand], None]] = None
+    
+    def set_energy_data(self, energy_data: EnergyData):
+        """Set the ENERGY data."""
+        self._energy_data = energy_data
+        self._check_data_initialized()
+
+    def set_metrics_data(self, metrics_data: MetricsData):
+        """Set the METRICS data."""
+        self._metrics_data = metrics_data
+        self._check_data_initialized()
+
+    def _check_data_initialized(self):
+        if self._energy_data and self._metrics_data and not self._data_initialized:
+            self._data_initialized = True
+            self.start_timers()
+            
+    def handle_command(self, payload: bytes):
+        """Handle WORKMODE commands."""
+        try:
+            message = payload.decode('utf-8')
+            if message.startswith("WORKMODE"):
+                json_part = message[len("WORKMODE "):]
+                data = json.loads(json_part)
+                command = WorkModeCommand.from_dict(data)
+                self._workmode_command = command
+                if self._on_command_callback:
+                    self._on_command_callback(command)
+        except Exception as e:
+            _logger.error(f"Error processing command message: {e}")
+
+    def set_command_callback(self, callback: Callable[[WorkModeCommand], None]):
+        """Set callback for command handling."""
+        self._on_command_callback = callback
+
+    def get_sensor_data(self) -> Dict[str, Any]:
+        """Get current sensor data."""
+        if not self._data_initialized:
+            return {}
+            
+        sensor_data = {
+            "Time": datetime.utcnow().isoformat(),
+            "POWER1": 0,
+            "ENERGY": self._energy_data.__dict__,
+            "METRICS": self._metrics_data.__dict__,
+            "WORKMODE": self._workmode_command.__dict__
+        }
+        return sensor_data
+
+    def get_state_data(self) -> Dict[str, Any]:
+        """Get current state data."""
+        return {
+            "Time": datetime.utcnow().isoformat(),
+            "Uptime": int((datetime.utcnow() - self._startup_utc).total_seconds()),
+        }

--- a/src/qilowatt/devices/power_switch.py
+++ b/src/qilowatt/devices/power_switch.py
@@ -1,0 +1,30 @@
+from ..base_device import BaseDevice
+from typing import Dict, Any
+from ..models import Status0Data
+
+class PowerSwitchDevice(BaseDevice):
+    """Implementation of a switch with power measurement."""
+    
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self._state = False
+        self._power = 0.0
+        self._voltage = 230.0
+        self._current = 0.0
+        self._data_initialized = True
+        self.start_timers()
+    
+    def handle_command(self, payload: bytes):
+        """Handle on/off commands."""
+        # Implement command handling for power switch
+        pass
+    
+    def get_sensor_data(self) -> Dict[str, Any]:
+        """Get current sensor data."""
+        # Implement sensor data for power switch
+        pass
+    
+    def get_state_data(self) -> Dict[str, Any]:
+        """Get current state data."""
+        # Implement state data for power switch
+        pass

--- a/src/qilowatt/devices/switch.py
+++ b/src/qilowatt/devices/switch.py
@@ -1,0 +1,67 @@
+from ..base_device import BaseDevice
+from typing import Dict, Any
+from typing import Callable, Optional
+from datetime import datetime
+import logging
+
+_logger = logging.getLogger(__name__)
+
+class SwitchDevice(BaseDevice):
+    """Implementation of a basic switch device."""
+    
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self._state = False
+        self._data_initialized = True  # Basic switch is always ready
+        self._on_switch_command_callback: Optional[Callable[[bool], None]] = None
+        self.start_timers()
+
+    def send_update(self):
+        """Send an update to the MQTT broker."""
+        self.publish_sensor_data()
+        self.publish_state_data()
+        self._publish_callback(self.power_topic, 1 if self._state else 0)
+    
+    def set_command_callback(self, callback: Callable[[bool], None]):
+        """Set callback for command handling."""
+        self._on_switch_command_callback = callback
+
+    def handle_command(self, payload: bytes):
+        """Handle on/off commands."""
+        try:
+            message = payload.decode('utf-8')
+            if message == "POWER1 1":
+                self.turn_on()
+            elif message == "POWER1 0":
+                self.turn_off()
+        except Exception as e:
+            _logger.error(f"Error processing command message: {e}")
+ 
+    def turn_on(self):
+        """Turn the switch on."""
+        self._state = True
+        self.send_update()
+        if self._on_switch_command_callback:
+            self._on_switch_command_callback(self._state)
+
+    def turn_off(self):
+        """Turn the switch off."""
+        self._state = False
+        self.send_update()
+        if self._on_switch_command_callback:
+            self._on_switch_command_callback(self._state)
+   
+    def get_sensor_data(self) -> Dict[str, Any]:
+        """Get current sensor data."""
+        return {
+            "Time": datetime.utcnow().isoformat(),
+            "Switch1": "ON" if self._state else "OFF"
+        }
+    
+    def get_state_data(self) -> Dict[str, Any]:
+        """Get current state data."""
+        return {
+            "Time": datetime.utcnow().isoformat(),
+            "Uptime": int((datetime.utcnow() - self._startup_utc).total_seconds()),
+            "POWER1": "ON" if self._state else "OFF",
+        }

--- a/src/qilowatt/devices/thermostat.py
+++ b/src/qilowatt/devices/thermostat.py
@@ -1,0 +1,29 @@
+from ..base_device import BaseDevice
+from typing import Dict, Any
+from ..models import Status0Data
+
+class ThermostatDevice(BaseDevice):
+    """Implementation of a thermostat device."""
+    
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self._temperature = 20.0
+        self._target_temperature = 21.0
+        self._mode = "heat"  # heat, cool, off
+        self._data_initialized = True
+        self.start_timers()
+    
+    def handle_command(self, payload: bytes):
+        """Handle temperature and mode commands."""
+        # Implement command handling for thermostat
+        pass
+    
+    def get_sensor_data(self) -> Dict[str, Any]:
+        """Get current sensor data."""
+        # Implement sensor data for thermostat
+        pass
+    
+    def get_state_data(self) -> Dict[str, Any]:
+        """Get current state data."""
+        # Implement state data for thermostat
+        pass


### PR DESCRIPTION
Enables implementing different device types. Now the used first needs to invoke a device class and then MQTT client. Every device can have it's own implementation for state, status and callbacks.