### PR TITLE
Add GenCurrent to SENSOR metrics

### DIFF
--- a/example-inverter.py
+++ b/example-inverter.py
@@ -57,6 +57,7 @@ metrics_data = MetricsData(
     BatteryVoltage=[48.0],
     GenVoltage=[0.0, 0.0, 0.0],
     GenPower=[0.0, 0.0, 0.0],
+    GenCurrent=[0.0, 0.0, 0.0],
     GridExportLimit=5000.0,
     BatteryTemperature=[30.0],
     InverterTemperature=40.0

--- a/src/qilowatt/models.py
+++ b/src/qilowatt/models.py
@@ -32,6 +32,7 @@ class MetricsData:
     BatteryVoltage: List[float]
     GenVoltage: List[float]
     GenPower: List[float]
+    GenCurrent: List[float]
     GridExportLimit: float
     BatteryTemperature: List[float]
     InverterTemperature: float


### PR DESCRIPTION
## Summary
- Adds `GenCurrent: List[float]` to `MetricsData` alongside existing `GenVoltage` and `GenPower` fields
- Updates example inverter script with the new field

## Test plan
- [x] All 8 existing tests pass
- [ ] Verify SENSOR payload includes GenCurrent in downstream integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)